### PR TITLE
Reduce stopwatch digit spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
       --btn-stop-pressed:#1b0706;
       --app-padding-inline-start: calc(30px + env(safe-area-inset-left));
       --app-padding-inline-end: calc(30px + env(safe-area-inset-right));
-      --time-digit-spacing: clamp(0.06em, 0.45vw, 0.12em);
-      --time-cell-gap: clamp(0.12em, 0.85vw, 0.24em);
+      --time-digit-spacing: clamp(0.03em, 0.225vw, 0.06em);
+      --time-cell-gap: clamp(0.06em, 0.425vw, 0.12em);
     }
 
     *{box-sizing:border-box; -webkit-tap-highlight-color: transparent;}


### PR DESCRIPTION
## Summary
- halve the stopwatch digit letter spacing and cell gap so numbers stay evenly spaced while taking less room

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc5e697efc83308c94c60842e468e9