### PR TITLE
Reduce stopwatch digit spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
       --btn-stop-pressed:#1b0706;
       --app-padding-inline-start: calc(30px + env(safe-area-inset-left));
       --app-padding-inline-end: calc(30px + env(safe-area-inset-right));
-      --time-digit-spacing: clamp(0.03em, 0.225vw, 0.06em);
-      --time-cell-gap: clamp(0.06em, 0.425vw, 0.12em);
+      --time-digit-spacing: clamp(0.015em, 0.1125vw, 0.03em);
+      --time-cell-gap: clamp(0.03em, 0.2125vw, 0.06em);
     }
 
     *{box-sizing:border-box; -webkit-tap-highlight-color: transparent;}


### PR DESCRIPTION
## Summary
- halve the stopwatch digit letter spacing variable to bring characters closer together
- decrease the inter-cell gap so colons and digit groups stay proportionally spaced

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc60a662a48330afbefe873f2b65f3