### PR TITLE
Adjust time digit spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
       --btn-stop-pressed:#1b0706;
       --app-padding-inline-start: calc(30px + env(safe-area-inset-left));
       --app-padding-inline-end: calc(30px + env(safe-area-inset-right));
-      --time-digit-spacing: clamp(0.015em, 0.1125vw, 0.03em);
+      --time-digit-spacing: clamp(0.0075em, 0.05625vw, 0.015em);
       --time-cell-gap: clamp(0.03em, 0.2125vw, 0.06em);
     }
 


### PR DESCRIPTION
## Summary
- halve the stopwatch digit letter-spacing custom property to tighten spacing while preserving uniform cell widths

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc620657fc8330bfee6807b8846dc1