### PR TITLE
Adjust stopwatch spacing and tab sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
       --btn-stop-pressed:#1b0706;
       --app-padding-inline-start: calc(30px + env(safe-area-inset-left));
       --app-padding-inline-end: calc(30px + env(safe-area-inset-right));
-      --time-digit-spacing: clamp(0.0075em, 0.05625vw, 0.015em);
-      --time-cell-gap: clamp(0.03em, 0.2125vw, 0.06em);
+      --time-digit-spacing: clamp(0.00375em, 0.028125vw, 0.0075em);
+      --time-cell-gap: clamp(0.015em, 0.10625vw, 0.03em);
     }
 
     *{box-sizing:border-box; -webkit-tap-highlight-color: transparent;}
@@ -185,13 +185,15 @@
       background:#000;
       display:flex; justify-content:space-between; align-items:center;
       font-size:12px;
-      padding: 0 30px;
+      padding: 0 34px;
+      gap: clamp(12px, 3vw, 22px);
     }
     .tab{
       height:100%; display:flex; flex-direction:column;
-      align-items:center; justify-content:center; gap:4px; user-select:none;
+      align-items:center; justify-content:center; gap:6px; user-select:none;
+      padding-inline: clamp(6px, 2vw, 12px);
     }
-    .tab .icon{width:24px; height:24px;}
+    .tab .icon{width:28px; height:28px;}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- halve the letter spacing and group gap on the stopwatch display to tighten digit alignment without shifting widths
- enlarge tab bar buttons with added padding, spacing, and icon size for a slightly wider appearance

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc660a67b0833092152b91e71e1479