### PR TITLE
Update PWA name to Часы

### DIFF
--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Секундомер",
-  "short_name": "Секундомер",
+  "name": "Часы",
+  "short_name": "Часы",
   "start_url": "./",
   "display": "standalone",
   "background_color": "#000000",


### PR DESCRIPTION
## Summary
- change the PWA manifest name and short_name to "Часы" so that the app shows the desired label when added to the home screen

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc6ae60fac83308b102501893a5f69